### PR TITLE
Add custom options and plugins

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,6 +25,7 @@ Installs, configures and runs the Elasticsearch service.
 ------------------------
 
 Configures Elasticsearch.
+Custom options can be specified via `custom_options` and are rendered as yaml in the elasticsearch config.
 
 ``elasticsearch.pkg``
 ---------------------

--- a/README.rst
+++ b/README.rst
@@ -47,3 +47,8 @@ Manages the Elasticsearch service.
 ---------------------------
 
 Configures defaults/sysconfig env vars for the Elasticsearch service.
+
+``elasticsearch.plugins``
+-------------------------
+
+Allows configuration of elasticsearch plugins.

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 Elasticsearch
-===============
+=============
 
 Formula to install and configure Elasticsearch.
 
@@ -22,27 +22,27 @@ Available states
 Installs, configures and runs the Elasticsearch service.
 
 ``elasticsearch.config``
------------
+------------------------
 
 Configures Elasticsearch.
 
 ``elasticsearch.pkg``
------------
+---------------------
 
 Installs Elasticsearch.
 
 ``elasticsearch.repo``
------------
+----------------------
 
 Adds the Elasticsearch pkg repo.
 
 
 ``elasticsearch.service``
------------
+-------------------------
 
 Manages the Elasticsearch service.
 
 ``elasticsearch.sysconfig``
------------
+---------------------------
 
 Configures defaults/sysconfig env vars for the Elasticsearch service.

--- a/elasticsearch/files/elasticsearch.yml
+++ b/elasticsearch/files/elasticsearch.yml
@@ -146,3 +146,10 @@ action.destructive_requires_name: {{ elasticsearch.config['action.destructive_re
 {%- else %}
 # action.destructive_requires_name: true
 {%- endif %}
+
+{%- if elasticsearch.config['custom_options'] is defined %}
+{% set custom_options = elasticsearch.config['custom_options'] %}
+{{ custom_options|yaml(False) }}
+{%- else %}
+# no custom options set
+{%- endif %}

--- a/elasticsearch/init.sls
+++ b/elasticsearch/init.sls
@@ -4,3 +4,4 @@ include:
   - elasticsearch.config
   - elasticsearch.sysconfig
   - elasticsearch.service
+  - elasticsearch.plugins

--- a/elasticsearch/repo.sls
+++ b/elasticsearch/repo.sls
@@ -7,6 +7,7 @@ elasticsearch_repo:
     - file: /etc/apt/sources.list.d/elasticsearch.list
     - keyid: D88E42B4
     - keyserver: keyserver.ubuntu.com
+    - clean_file: true
     {% elif grains['os_family'] == 'RedHat' %}
     - name: elasticsearch
     - baseurl: http://packages.elastic.co/elasticsearch/2.x/centos

--- a/pillar.example
+++ b/pillar.example
@@ -13,6 +13,10 @@ elasticsearch:
     gateway.recover_after_nodes: 3
     node.max_local_storage_nodes: 1
     action.destructive_requires_name: true
+    custom_options:
+      indices:
+        memory:
+          index_buffer_size: 50%
   sysconfig:
     ES_STARTUP_SLEEP_TIME: 5
     ES_HEAP_SIZE: 8g

--- a/pillar.example
+++ b/pillar.example
@@ -21,3 +21,5 @@ elasticsearch:
     ES_STARTUP_SLEEP_TIME: 5
     ES_HEAP_SIZE: 8g
     MAX_OPEN_FILES: 65535
+  plugins:
+    kopf: lmenezes/elasticsearch-kopf


### PR DESCRIPTION
`custom_options` allow specifying a generic config option, not just the default ones in the `elasticsearch.yaml` config file.
`plugins.sls` allows installing plugins alongside with elasticsearch.