### PR TITLE
Specify protocol and port in keyserver string

### DIFF
--- a/elasticsearch/repo.sls
+++ b/elasticsearch/repo.sls
@@ -6,7 +6,7 @@ elasticsearch_repo:
     - dist: stable
     - file: /etc/apt/sources.list.d/elasticsearch.list
     - keyid: D88E42B4
-    - keyserver: keyserver.ubuntu.com
+    - keyserver: hkp://keyserver.ubuntu.com:80
     - clean_file: true
     {% elif grains['os_family'] == 'RedHat' %}
     - name: elasticsearch


### PR DESCRIPTION
For some reason, which can probably be found in the inner workings of salt and/or apt package management, I experience inconsistent behavior and errors when the protocol and port are not specified in the keyserver value.

For example these states were run from the same host, within a couple of minutes, with only with the mentioned change differing.

No specific protocol and port:

```
----------
          ID: elasticsearch_repo
    Function: pkgrepo.managed
        Name: deb http://packages.elastic.co/elasticsearch/2.x/debian stable main
      Result: False
     Comment: Failed to configure repo 'deb http://packages.elastic.co/elasticsearch/2.x/debian stable main': Error: key retrieval failed: Executing: gpg --ignore-time-conflict --no-options --no-default-keyring --homedir /tmp/tmp.UDwkcmk7CM --no-auto-check-trustdb --trust-model always --keyring /etc/apt/trusted.gpg --primary-keyring /etc/apt/trusted.gpg --keyring /etc/apt/trusted.gpg.d/debian-archive-jessie-automatic.gpg --keyring /etc/apt/trusted.gpg.d/debian-archive-jessie-security-automatic.gpg --keyring /etc/apt/trusted.gpg.d/debian-archive-jessie-stable.gpg --keyring /etc/apt/trusted.gpg.d/debian-archive-squeeze-automatic.gpg --keyring /etc/apt/trusted.gpg.d/debian-archive-squeeze-stable.gpg --keyring /etc/apt/trusted.gpg.d/debian-archive-wheezy-automatic.gpg --keyring /etc/apt/trusted.gpg.d/debian-archive-wheezy-stable.gpg --keyserver keyserver.ubuntu.com --logger-fd 1 --recv-keys D88E42B4
              ?: keyserver.ubuntu.com: Connection refused
              gpgkeys: HTTP fetch error 7: couldn't connect: Connection refused
              gpg: requesting key D88E42B4 from hkp server keyserver.ubuntu.com
              gpg: no valid OpenPGP data found.
              gpg: Total number processed: 0
     Started: 09:50:21.710343
    Duration: 270.828 ms
     Changes:
```

Protocol and port specified:

```
----------
          ID: elasticsearch_repo
    Function: pkgrepo.managed
        Name: deb http://packages.elastic.co/elasticsearch/2.x/debian stable main
      Result: True
     Comment: Configured package repo 'deb http://packages.elastic.co/elasticsearch/2.x/debian stable main'
     Started: 09:52:51.379050
    Duration: 4672.844 ms
     Changes:   
              ----------
              repo:
                  deb http://packages.elastic.co/elasticsearch/2.x/debian stable main
```
