### PR TITLE
Create pillar for setting memory dynamically

### DIFF
--- a/elasticsearch/sysconfig.sls
+++ b/elasticsearch/sysconfig.sls
@@ -7,7 +7,15 @@ include:
 {% set sysconfig_file = '/etc/sysconfig/elasticsearch' %}
 {% endif %}
 
-{% set sysconfig_data = salt['pillar.get']('elasticsearch:sysconfig') %}
+{% set sysconfig_data = salt['pillar.get']('elasticsearch:sysconfig', {}) %}
+
+{% set heap_percentage = salt['pillar.fetch']('elasticsearch:heap_size_percentage', 0) %}
+{% set heap_size = (salt['grains.get']('mem_total') * heap_percentage)|round(0)|int %}
+
+{% if heap_size %}
+{% do sysconfig_data.update({'ES_HEAP_SIZE': "{0}m".format(heap_size)}) %}
+{% endif %}
+
 {% if sysconfig_data %}
 {{ sysconfig_file }}:
   file.managed:
@@ -19,5 +27,5 @@ include:
     - watch_in:
       - service: elasticsearch_service
     - context:
-        sysconfig: {{ salt['pillar.get']('elasticsearch:sysconfig') }}
+        sysconfig: {{ sysconfig_data }}
 {% endif %}

--- a/elasticsearch/sysconfig.sls
+++ b/elasticsearch/sysconfig.sls
@@ -9,8 +9,8 @@ include:
 
 {% set sysconfig_data = salt['pillar.get']('elasticsearch:sysconfig', {}) %}
 
-{% set heap_percentage = salt['pillar.fetch']('elasticsearch:heap_size_percentage', 0) %}
-{% set heap_size = (salt['grains.get']('mem_total') * heap_percentage)|round(0)|int %}
+{% set heap_ratio = salt['pillar.fetch']('elasticsearch:heap_size_ratio', 0) %}
+{% set heap_size = (salt['grains.get']('mem_total') * heap_ratio)|round(0)|int %}
 
 {% if heap_size %}
 {% do sysconfig_data.update({'ES_HEAP_SIZE': "{0}m".format(heap_size)}) %}

--- a/pillar.example
+++ b/pillar.example
@@ -18,7 +18,7 @@ elasticsearch:
         memory:
           index_buffer_size: 50%
   # This over-rides the ES_HEAP_SIZE set below to be 45% of memory
-  heap_size_percentage: 0.45
+  heap_size_ratio: 0.45
   sysconfig:
     ES_STARTUP_SLEEP_TIME: 5
     ES_HEAP_SIZE: 8g

--- a/pillar.example
+++ b/pillar.example
@@ -17,6 +17,8 @@ elasticsearch:
       indices:
         memory:
           index_buffer_size: 50%
+  # This over-rides the ES_HEAP_SIZE set below to be 45% of memory
+  heap_size_percentage: 0.45
   sysconfig:
     ES_STARTUP_SLEEP_TIME: 5
     ES_HEAP_SIZE: 8g


### PR DESCRIPTION
ElasticSearch [recommend giving less than 50% of memory to elasticsearch](https://www.elastic.co/guide/en/elasticsearch/guide/current/heap-sizing.html#_give_less_than_half_your_memory_to_lucene). It seems logical to provide users with an easy way to do this, since we have the grains to support it.

This change allows users to set a pillar of `elasticsearch:heap_size_ratio` that calculates the appropriate amount of memory to give elasticsearch.
