### PR TITLE
repo change via major_version

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -29,6 +29,23 @@ suites:
           elasticsearch:
             config:
               network.host: 0.0.0.0
+  - name: version-5.0
+    driver_config:
+      provision_command:
+        - apt-get update  # base image is out of date
+        - apt-get install -y software-properties-common  # required for add-apt-repository
+        - add-apt-repository -y ppa:openjdk-r/ppa
+        - apt-get update
+        - apt-get install -y openjdk-8-jre-headless
+    provisioner:
+      pillars:
+        top.sls:
+          base:
+            '*':
+              - elasticsearch
+        elasticsearch.sls:
+          elasticsearch:
+            major_version: 5
 
 verifier:
   name: shell

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 Elasticsearch
 =============
 
-Formula to install and configure Elasticsearch.
+Formula to install and configure Elasticsearch. Supports 2.x and 5.x.
 
 
 .. note::

--- a/elasticsearch/pkg.sls
+++ b/elasticsearch/pkg.sls
@@ -1,3 +1,5 @@
+{%- set major_version = salt['pillar.get']('elasticsearch:major_version', 2) %}
+
 include:
   - elasticsearch.repo
 
@@ -6,5 +8,6 @@ include:
 elasticsearch_pkg:
   pkg.installed:
     - name: {{ elasticsearch.pkg }}
+    - version: {{ major_version }}.*
     - require:
       - sls: elasticsearch.repo

--- a/elasticsearch/repo.sls
+++ b/elasticsearch/repo.sls
@@ -1,17 +1,38 @@
+{%- set major_version = salt['pillar.get']('elasticsearch:major_version', 2) %}
+
+{%- if major_version == 5 %}
+  {%- set repo_url = 'https://artifacts.elastic.co/packages/5.x' %}
+{%- else %}
+  {%- set repo_url = 'http://packages.elastic.co/elasticsearch/2.x' %}
+{%- endif %}
+
+{%- if major_version == 5 %}
+apt-transport-https:
+  pkg.installed
+{%- endif %}
+
 elasticsearch_repo:
   pkgrepo.managed:
-    - humanname: Elasticsearch 2.
-    {% if grains.get('os_family') == 'Debian' %}
-    - name: deb http://packages.elastic.co/elasticsearch/2.x/debian stable main
+    - humanname: Elasticsearch {{ major_version }}
+{%- if grains.get('os_family') == 'Debian' %}
+  {%- if major_version == 5 %}
+    - name: deb {{ repo_url }}/apt stable main
+  {%- else %}
+    - name: deb {{ repo_url }}/debian stable main
+  {%- endif %}
     - dist: stable
     - file: /etc/apt/sources.list.d/elasticsearch.list
     - keyid: D88E42B4
     - keyserver: keyserver.ubuntu.com
     - clean_file: true
-    {% elif grains['os_family'] == 'RedHat' %}
+{%- elif grains['os_family'] == 'RedHat' %}
     - name: elasticsearch
-    - baseurl: http://packages.elastic.co/elasticsearch/2.x/centos
+  {%- if major_version == 5 %}
+    - baseurl: {{ repo_url }}/centos
+  {%- else %}
+    - baseurl: {{ repo_url }}/centos
+  {%- endif %}
     - enabled: 1
     - gpgcheck: 1
-    - gpgkey: http://packages.elastic.co/GPG-KEY-elasticsearch
-    {% endif %}
+    - gpgkey: http://artifacts.elastic.co/GPG-KEY-elasticsearch
+{%- endif %}

--- a/elasticsearch/service.sls
+++ b/elasticsearch/service.sls
@@ -11,4 +11,4 @@ elasticsearch_service:
       - file: elasticsearch_cfg
 {%- endif %}
     - require:
-      - sls: elasticsearch.pkg
+      - pkg: elasticsearch

--- a/pillar.example
+++ b/pillar.example
@@ -1,4 +1,5 @@
 elasticsearch:
+  major_version: 2
   config:
     cluster.name: my-application
     node.name: node2

--- a/test/integration/version-5.0/testinfra/test_elasticsearch.py
+++ b/test/integration/version-5.0/testinfra/test_elasticsearch.py
@@ -1,0 +1,12 @@
+import testinfra
+
+
+def test_package_in_installed(Package):
+    elasticsearch = Package('elasticsearch')
+    assert elasticsearch.is_installed
+    assert elasticsearch.version.startswith('5.0')
+
+def test_service_is_running_and_enabled(Service):
+    elasticsearch = Service('elasticsearch')
+    assert elasticsearch.is_running
+    assert elasticsearch.is_enabled


### PR DESCRIPTION
This allows users to install ElasticSearch `2.x` or `5.x`.

With this, users can't specify the exact version. I'm up creating something more flexible now or later.

Behavior
-----------

* no value or `2': as the formula works now
* `5`: installs 5.x from new repo
* from `2` to `5`: installs 5.x in place of 2.x, data upgraded (i think)
* from `5` to `2`: service tries to start on every highstate (systemd)