### PR TITLE
[elasticsearch/sysconfig] use ini_manage

### DIFF
--- a/elasticsearch/sysconfig.sls
+++ b/elasticsearch/sysconfig.sls
@@ -10,14 +10,11 @@ include:
 {% set sysconfig_data = salt['pillar.get']('elasticsearch:sysconfig') %}
 {% if sysconfig_data %}
 {{ sysconfig_file }}:
-  file.managed:
-    - source: salt://elasticsearch/files/sysconfig
-    - owner: elasticsearch
-    - group: elasticsearch
-    - mode: 0600
-    - template: jinja
+  ini.options_present:
     - watch_in:
       - service: elasticsearch_service
-    - context:
-        sysconfig: {{ salt['pillar.get']('elasticsearch:sysconfig') }}
+    - sections:
+          {%- for k,v in salt['pillar.get']('elasticsearch:sysconfig').items() %}
+          {{ k }}: '{{ v }}'
+          {%- endfor %}
 {% endif %}


### PR DESCRIPTION
instead of file.managed, so we can keep documentation
comments and the other variables one can tweak

solves #21 