### PR TITLE
Fix v5 yum repo url

### DIFF
--- a/elasticsearch/repo.sls
+++ b/elasticsearch/repo.sls
@@ -6,7 +6,7 @@
   {%- set repo_url = 'http://packages.elastic.co/elasticsearch/2.x' %}
 {%- endif %}
 
-{%- if major_version == 5 %}
+{%- if major_version == 5 and grains['os_family'] == 'Debian' %}
 apt-transport-https:
   pkg.installed
 {%- endif %}
@@ -28,7 +28,7 @@ elasticsearch_repo:
 {%- elif grains['os_family'] == 'RedHat' %}
     - name: elasticsearch
   {%- if major_version == 5 %}
-    - baseurl: {{ repo_url }}/centos
+    - baseurl: {{ repo_url }}/yum
   {%- else %}
     - baseurl: {{ repo_url }}/centos
   {%- endif %}


### PR DESCRIPTION
Based on the latest docs...

https://www.elastic.co/guide/en/elasticsearch/reference/current/rpm.html

The yum repo url should end with /yum

However, based on the 2.1 docs...

https://www.elastic.co/guide/en/elasticsearch/reference/2.1/setup-repositories.html

It should end with /centos

Also don't try to install apt-transport-https on rpm systems.