### PR TITLE
Default JAVA_HOME value, don't manage sysconfig twice

### DIFF
--- a/elasticsearch/files/sysconfig
+++ b/elasticsearch/files/sysconfig
@@ -1,10 +1,6 @@
-{%- if not sysconfig %}
+{%- if 'JAVA_HOME' not in sysconfig.keys() %}
 JAVA_HOME=/usr/lib/java
-{% else %}
-{%- if 'java_home' not in sysconfig.keys() %}
-JAVA_HOME=/usr/lib/java
-{% endif %}
+{%- endif %}
 {%- for key, value in sysconfig.iteritems() -%}
 {{ key }}={{ value }}
 {% endfor %}
-{% endif -%}

--- a/elasticsearch/files/sysconfig
+++ b/elasticsearch/files/sysconfig
@@ -1,3 +1,10 @@
+{%- if not sysconfig %}
+JAVA_HOME=/usr/lib/java
+{% else %}
+{%- if 'java_home' not in sysconfig.keys() %}
+JAVA_HOME=/usr/lib/java
+{% endif %}
 {%- for key, value in sysconfig.iteritems() -%}
 {{ key }}={{ value }}
 {% endfor %}
+{% endif -%}

--- a/elasticsearch/sysconfig.sls
+++ b/elasticsearch/sysconfig.sls
@@ -17,4 +17,4 @@ include:
     - watch_in:
       - service: elasticsearch_service
     - context:
-        sysconfig: {{ salt['pillar.get']('elasticsearch:sysconfig') }}
+        sysconfig: {{ salt['pillar.get']('elasticsearch:sysconfig', '{}') }}

--- a/elasticsearch/sysconfig.sls
+++ b/elasticsearch/sysconfig.sls
@@ -7,8 +7,6 @@ include:
 {% set sysconfig_file = '/etc/sysconfig/elasticsearch' %}
 {% endif %}
 
-{% set sysconfig_data = salt['pillar.get']('elasticsearch:sysconfig') %}
-{% if sysconfig_data %}
 {{ sysconfig_file }}:
   file.managed:
     - source: salt://elasticsearch/files/sysconfig
@@ -20,14 +18,3 @@ include:
       - service: elasticsearch_service
     - context:
         sysconfig: {{ salt['pillar.get']('elasticsearch:sysconfig') }}
-{% endif %}
-
-{%- set java_home = salt['pillar.get']('elasticsearch:java_home', '/usr/lib/java') %}
-manage Elasticsearch JAVA_HOME in environment file:
-  file.replace:
-    - name: {{ sysconfig_file }}
-    - pattern: ^[\s#]*JAVA_HOME=.*$
-    - repl: JAVA_HOME={{ java_home }}
-    - prepend_if_not_found: true
-    - watch_in:
-      - service: elasticsearch

--- a/pillar.example
+++ b/pillar.example
@@ -1,6 +1,5 @@
 elasticsearch:
   major_version: 2
-  java_home: /usr/bin/java
   config:
     cluster.name: my-application
     node.name: node2


### PR DESCRIPTION
file.replace was added to set JAVA_HOME in the sysconfig file, but that
results in the file changing every time the state is applied... and
then ElasticSearch restarts every time too.

I think setting your own JAVA_HOME in pillar is fine, but if you really
want to edit the file file.prepend would probably be best.

@blbradley 