### PR TITLE
Manage /etc/elasticsearch/jvm.options for ES5

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -59,26 +59,7 @@ suites:
             plugins:
               lang-python: lang-python
             jvm_opts:
-              - -Xms2g
-              - -Xmx2g
-              - -XX:+UseConcMarkSweepGC
-              - -XX:CMSInitiatingOccupancyFraction=75
-              - -XX:+UseCMSInitiatingOccupancyOnly
-              - -XX:+DisableExplicitGC
-              - -XX:+AlwaysPreTouch
-              - -server
-              - -Xss1m
-              - -Djava.awt.headless=true
-              - -Dfile.encoding=UTF-8
-              - -Djna.nosys=true
-              - -Djdk.io.permissionsUseCanonicalPath=true
-              - -Dio.netty.noUnsafe=true
-              - -Dio.netty.noKeySetOptimization=true
-              - -Dio.netty.recycler.maxCapacityPerThread=0
-              - -Dlog4j.shutdownHookEnabled=false
-              - -Dlog4j2.disable.jmx=true
-              - -Dlog4j.skipJansi=true
-              - -XX:+HeapDumpOnOutOfMemoryError
+              - '# Test String'
 
 verifier:
   name: shell

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -58,6 +58,27 @@ suites:
             major_version: 5
             plugins:
               lang-python: lang-python
+            jvm_opts:
+              - -Xms2g
+              - -Xmx2g
+              - -XX:+UseConcMarkSweepGC
+              - -XX:CMSInitiatingOccupancyFraction=75
+              - -XX:+UseCMSInitiatingOccupancyOnly
+              - -XX:+DisableExplicitGC
+              - -XX:+AlwaysPreTouch
+              - -server
+              - -Xss1m
+              - -Djava.awt.headless=true
+              - -Dfile.encoding=UTF-8
+              - -Djna.nosys=true
+              - -Djdk.io.permissionsUseCanonicalPath=true
+              - -Dio.netty.noUnsafe=true
+              - -Dio.netty.noKeySetOptimization=true
+              - -Dio.netty.recycler.maxCapacityPerThread=0
+              - -Dlog4j.shutdownHookEnabled=false
+              - -Dlog4j2.disable.jmx=true
+              - -Dlog4j.skipJansi=true
+              - -XX:+HeapDumpOnOutOfMemoryError
 
 verifier:
   name: shell

--- a/elasticsearch/init.sls
+++ b/elasticsearch/init.sls
@@ -3,5 +3,6 @@ include:
   - elasticsearch.pkg
   - elasticsearch.config
   - elasticsearch.sysconfig
+  - elasticsearch.jvmopts
   - elasticsearch.service
   - elasticsearch.plugins

--- a/elasticsearch/jvmopts.sls
+++ b/elasticsearch/jvmopts.sls
@@ -3,7 +3,7 @@ include:
 
 {%- set major_version = salt['pillar.get']('elasticsearch:major_version', 2) %}
 
-{%- if major_version >= 5 %}
+{%- if major_version == 5 %}
 {%- set jvm_opts = salt['pillar.get']('elasticsearch:jvm_opts') %}
 {%- if jvm_opts %}
 /etc/elasticsearch/jvm.options:

--- a/elasticsearch/jvmopts.sls
+++ b/elasticsearch/jvmopts.sls
@@ -1,0 +1,18 @@
+include:
+  - elasticsearch.service
+
+{%- set major_version = salt['pillar.get']('elasticsearch:major_version', 2) %}
+
+{%- if major_version >= 5 %}
+{%- set jvm_opts = salt['pillar.get']('elasticsearch:jvm_opts') %}
+{%- if jvm_opts %}
+/etc/elasticsearch/jvm.options:
+  file.managed:
+    - mode: 0770
+    - owner: elasticsearch
+    - group: elasticsearch
+    - contents: {{ jvm_opts }}
+    - watch_in:
+      - service: elasticsearch
+{% endif -%}
+{% endif -%}

--- a/pillar.example
+++ b/pillar.example
@@ -21,24 +21,3 @@ elasticsearch:
   plugins:
     lang-python: lang-python
     kopf: lmenezes/elasticsearch-kopf
-  jvm_opts:
-    - -Xms2g
-    - -Xmx2g
-    - -XX:+UseConcMarkSweepGC
-    - -XX:CMSInitiatingOccupancyFraction=75
-    - -XX:+UseCMSInitiatingOccupancyOnly
-    - -XX:+DisableExplicitGC
-    - -XX:+AlwaysPreTouch
-    - -server
-    - -Xss1m
-    - -Djava.awt.headless=true
-    - -Dfile.encoding=UTF-8
-    - -Djna.nosys=true
-    - -Djdk.io.permissionsUseCanonicalPath=true
-    - -Dio.netty.noUnsafe=true
-    - -Dio.netty.noKeySetOptimization=true
-    - -Dio.netty.recycler.maxCapacityPerThread=0
-    - -Dlog4j.shutdownHookEnabled=false
-    - -Dlog4j2.disable.jmx=true
-    - -Dlog4j.skipJansi=true
-    - -XX:+HeapDumpOnOutOfMemoryError

--- a/pillar.example
+++ b/pillar.example
@@ -21,3 +21,24 @@ elasticsearch:
   plugins:
     lang-python: lang-python
     kopf: lmenezes/elasticsearch-kopf
+  jvm_opts:
+    - -Xms2g
+    - -Xmx2g
+    - -XX:+UseConcMarkSweepGC
+    - -XX:CMSInitiatingOccupancyFraction=75
+    - -XX:+UseCMSInitiatingOccupancyOnly
+    - -XX:+DisableExplicitGC
+    - -XX:+AlwaysPreTouch
+    - -server
+    - -Xss1m
+    - -Djava.awt.headless=true
+    - -Dfile.encoding=UTF-8
+    - -Djna.nosys=true
+    - -Djdk.io.permissionsUseCanonicalPath=true
+    - -Dio.netty.noUnsafe=true
+    - -Dio.netty.noKeySetOptimization=true
+    - -Dio.netty.recycler.maxCapacityPerThread=0
+    - -Dlog4j.shutdownHookEnabled=false
+    - -Dlog4j2.disable.jmx=true
+    - -Dlog4j.skipJansi=true
+    - -XX:+HeapDumpOnOutOfMemoryError

--- a/test/integration/version-5.0/testinfra/test_elasticsearch.py
+++ b/test/integration/version-5.0/testinfra/test_elasticsearch.py
@@ -13,3 +13,6 @@ def test_service_is_running_and_enabled(Service):
     elasticsearch = Service('elasticsearch')
     assert elasticsearch.is_running
     assert elasticsearch.is_enabled
+
+def test_jvm_opts(File):
+    assert File('/etc/elasticsearch/jvm.options').contains('# Test String')


### PR DESCRIPTION
I'm using a combination of /etc/sysconfig/elasticsearch which is managed
by this formula and /etc/elasticsearch/jvm.options which is not.
I think it's best to give users the option to use all the config files,
so this simply populates jvm.options from Pillar. I've added the
defaults from jvm.options on a fresh installation to the example Pillar
too.

Closes issue #20.