### PR TITLE
Sysconfig should keep new line after JAVA_HOME

### DIFF
--- a/elasticsearch/files/sysconfig
+++ b/elasticsearch/files/sysconfig
@@ -1,6 +1,6 @@
 {%- if 'JAVA_HOME' not in sysconfig.keys() %}
 JAVA_HOME=/usr/lib/java
-{%- endif %}
+{% endif %}
 {%- for key, value in sysconfig.iteritems() -%}
 {{ key }}={{ value }}
 {% endfor %}


### PR DESCRIPTION
Currently the sysconfig doesn't contain a new line after the JAVA_HOME config line.
That leads to a broken config, if further sysconfig values are inserted.

This pull request fixes this problem.