### PR TITLE
Ensure directory permissions are set prior to service start

### DIFF
--- a/elasticsearch/config.sls
+++ b/elasticsearch/config.sls
@@ -23,5 +23,7 @@ elasticsearch_cfg:
     - group: elasticsearch
     - mode: 0700
     - makedirs: True
+    - require_in:
+      - service: elasticsearch
 {% endif %}
 {% endfor %}


### PR DESCRIPTION

On the first run, the service can try to start prior to configuring the directories. This can lead to a failure to start elasticsearch until a subsequent run is performed.