### PR TITLE
Change file state owner to user

### DIFF
--- a/elasticsearch/jvmopts.sls
+++ b/elasticsearch/jvmopts.sls
@@ -9,7 +9,7 @@ include:
 /etc/elasticsearch/jvm.options:
   file.managed:
     - mode: 0770
-    - owner: elasticsearch
+    - user: elasticsearch
     - group: elasticsearch
     - contents: {{ jvm_opts }}
     - watch_in:

--- a/elasticsearch/sysconfig.sls
+++ b/elasticsearch/sysconfig.sls
@@ -10,7 +10,7 @@ include:
 {{ sysconfig_file }}:
   file.managed:
     - source: salt://elasticsearch/files/sysconfig
-    - owner: elasticsearch
+    - user: elasticsearch
     - group: elasticsearch
     - mode: 0600
     - template: jinja


### PR DESCRIPTION

The file state does not support an owner setting so it is renamed to user.