### PR TITLE
Add elasticsearch:add_repo pillar

### DIFF
--- a/elasticsearch/init.sls
+++ b/elasticsearch/init.sls
@@ -1,5 +1,7 @@
 include:
+{% if salt['pillar.get']('elasticsearch:add_repo', True) %}
   - elasticsearch.repo
+{% endif %}
   - elasticsearch.pkg
   - elasticsearch.config
   - elasticsearch.sysconfig

--- a/elasticsearch/pkg.sls
+++ b/elasticsearch/pkg.sls
@@ -1,5 +1,7 @@
+{% if salt['pillar.get']('elasticsearch:add_repo', True) %}
 include:
   - elasticsearch.repo
+{% endif %}
 
 {% from "elasticsearch/map.jinja" import elasticsearch_map with context %}
 {% from "elasticsearch/settings.sls" import elasticsearch with context %}
@@ -10,5 +12,7 @@ elasticsearch_pkg:
     {% if elasticsearch.version %}
     - version: {{ elasticsearch.version }}
     {% endif %}
+{% if salt['pillar.get']('elasticsearch:add_repo', True) %}
     - require:
       - sls: elasticsearch.repo
+{% endif %}

--- a/pillar.example
+++ b/pillar.example
@@ -1,4 +1,5 @@
 elasticsearch:
+  add_repo: True
   version: 2.4.2-1
   config:
     cluster.name: my-application


### PR DESCRIPTION
There are setups where adding the elasticsearch repo is not wanted, and
in other cases (Distro != Debian or RedHat) it's even broken in
elasticsearch-formula.

Therefore add a pillar (add_repo) that allows to disable adding the repo.

add_repo defaults to True for backward compability.

CC @ccboltz @tampakrap