### PR TITLE
Specify ES configuration for OSes with systemd

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -60,6 +60,9 @@ suites:
               lang-python: lang-python
             jvm_opts:
               - '# Test String'
+            systemd:
+              Service:
+                '# Test': String
 
 verifier:
   name: shell

--- a/README.rst
+++ b/README.rst
@@ -53,6 +53,11 @@ Configures defaults/sysconfig env vars for the Elasticsearch service.
 
 Allows configuration of elasticsearch plugins.
 
+``elasticsearch.systemd``
+-------------------------
+
+Configure system limits for the Elasticsearch service [on systems that use systemd](https://www.elastic.co/guide/en/elasticsearch/reference/current/setting-system-settings.html#systemd).
+
 
 Notes
 =====

--- a/elasticsearch/files/systemd.conf
+++ b/elasticsearch/files/systemd.conf
@@ -1,0 +1,6 @@
+{%- for section, unit in systemd.iteritems() -%}
+[{{ section }}]
+{% for key, value in unit.iteritems() -%}
+{{ key }}={{ value }}
+{% endfor %}
+{% endfor %}

--- a/elasticsearch/init.sls
+++ b/elasticsearch/init.sls
@@ -4,5 +4,6 @@ include:
   - elasticsearch.config
   - elasticsearch.sysconfig
   - elasticsearch.jvmopts
+  - elasticsearch.systemd
   - elasticsearch.service
   - elasticsearch.plugins

--- a/elasticsearch/systemd.sls
+++ b/elasticsearch/systemd.sls
@@ -1,0 +1,31 @@
+include:
+  - elasticsearch.pkg
+
+{%- if salt['pillar.get']('elasticsearch:systemd') %}
+/etc/systemd/system/elasticsearch.service.d:
+  file.directory:
+    - user: root
+    - group: root
+    - mode: 0755
+    - makedirs: True
+    - require_in:
+      - service: elasticsearch
+
+/etc/systemd/system/elasticsearch.service.d/elasticsearch.conf:
+  file.managed:
+    - source: salt://elasticsearch/files/systemd.conf
+    - user: root
+    - group: root
+    - mode: 0644
+    - template: jinja
+    - require:
+      - sls: elasticsearch.pkg
+    - watch_in:
+      - service: elasticsearch_service
+    - context:
+        systemd: {{ salt['pillar.get']('elasticsearch:systemd') }}
+  module.run:
+    - name: service.systemctl_reload
+    - onchanges:
+      - file: /etc/systemd/system/elasticsearch.service.d/elasticsearch.conf
+{%- endif %}

--- a/test/integration/version-5.0/testinfra/test_elasticsearch.py
+++ b/test/integration/version-5.0/testinfra/test_elasticsearch.py
@@ -16,3 +16,6 @@ def test_service_is_running_and_enabled(Service):
 
 def test_jvm_opts(File):
     assert File('/etc/elasticsearch/jvm.options').contains('# Test String')
+
+def test_systemd_config(File):
+    assert File('/etc/systemd/system/elasticsearch.service.d/elasticsearch.conf').contains('# Test=String')


### PR DESCRIPTION
On systems with systemd, system limits must be specified via [a systemd service file](https://www.elastic.co/guide/en/elasticsearch/reference/current/setting-system-settings.html). This PR adds that. The service file is only created if `elasticsearch.systemd` is specified.

I tried to use `file.serialize` with an ini formatter, but that doesn't maintain the case of the keys, and systemd is case sensitive. So I used a jinja template.

Let me know anything needs fixing.