### PR TITLE
Add use_repo switch to disable the use of the official repository

### DIFF
--- a/elasticsearch/init.sls
+++ b/elasticsearch/init.sls
@@ -1,5 +1,4 @@
 include:
-  - elasticsearch.repo
   - elasticsearch.pkg
   - elasticsearch.config
   - elasticsearch.sysconfig

--- a/elasticsearch/map.jinja
+++ b/elasticsearch/map.jinja
@@ -1,6 +1,7 @@
 {% set elasticsearch_map = salt['grains.filter_by']({
     'default': {
         'pkg': 'elasticsearch',
+        'use_repo': True,
     },
 },
 merge=salt['pillar.get']('elasticsearch:lookup', {}),

--- a/elasticsearch/pkg.sls
+++ b/elasticsearch/pkg.sls
@@ -1,8 +1,10 @@
-include:
-  - elasticsearch.repo
-
 {% from "elasticsearch/map.jinja" import elasticsearch_map with context %}
 {% from "elasticsearch/settings.sls" import elasticsearch with context %}
+
+{% if elasticsearch_map.use_repo %}
+include:
+  - elasticsearch.repo
+{% endif %}
 
 elasticsearch_pkg:
   pkg.installed:
@@ -10,5 +12,7 @@ elasticsearch_pkg:
     {% if elasticsearch.version %}
     - version: {{ elasticsearch.version }}
     {% endif %}
+    {% if elasticsearch_map.use_repo %}
     - require:
       - sls: elasticsearch.repo
+    {% endif %}

--- a/pillar.example
+++ b/pillar.example
@@ -1,5 +1,6 @@
 elasticsearch:
   version: 2.4.2-1
+  use_repo: True
   config:
     cluster.name: my-application
     node.name: node2


### PR DESCRIPTION
Hi,

I add possibility to disable the use of official repository with one pillar switch. Our use case is to use an internal repository that hosts the ElasticSearch package.

The MongoDB formula use the same convention to disable the usage of default repository : https://github.com/saltstack-formulas/mongodb-formula

Regards,

Nicolas