### PR TITLE
Control from pillar if the service is running and elabled

### DIFF
--- a/elasticsearch/service.sls
+++ b/elasticsearch/service.sls
@@ -3,9 +3,10 @@ include:
   - elasticsearch.config
 
 elasticsearch_service:
-  service.running:
+  service:
+    - {{ "running" if salt['pillar.get']('elasticsearch:running', True) else "dead" }}
     - name: elasticsearch
-    - enable: True
+    - enable: {{ salt['pillar.get']('elasticsearch:enabled', True) }}
 {%- if salt['pillar.get']('elasticsearch:config') %}
     - watch:
       - file: elasticsearch_cfg

--- a/pillar.example
+++ b/pillar.example
@@ -1,5 +1,7 @@
 elasticsearch:
   version: 2.4.2-1
+  enabled: True
+  running: True
   config:
     cluster.name: my-application
     node.name: node2


### PR DESCRIPTION
Making it possible to control from pillars if service is running and / or enabled. The idea is identical to the one in rabbitmq formula: https://github.com/saltstack-formulas/rabbitmq-formula

In my use case, I create an AWS image where I use this saltstack formula to install elasticsearch. Still, at this point I don't know final configuration and therefore I don't want that elasticsearch runs.

In latter steps, I create aws ec2 instance of previously created image. Then salt stack will do the final configuration of elasticsearch and finally start the service.