### PR TITLE
Drop ":lookup" from map.jinja to fix use_repo pillar

### DIFF
--- a/elasticsearch/map.jinja
+++ b/elasticsearch/map.jinja
@@ -4,6 +4,6 @@
         'use_repo': True,
     },
 },
-merge=salt['pillar.get']('elasticsearch:lookup', {}),
+merge=salt['pillar.get']('elasticsearch', {}),
 default='default')
 %}


### PR DESCRIPTION
pillar.example says that elasticsearch:use_repo controls using the repo,
but in reality elasticsearch:lookup:use_repo is needed.

The additional :lookup doesn't make sense, therefore drop it from
map.jinja so that elasticsearch:use_repo really works.