### PR TITLE
update for version 6 of elasticsearch

### DIFF
--- a/elasticsearch/jvmopts.sls
+++ b/elasticsearch/jvmopts.sls
@@ -3,7 +3,7 @@ include:
 
 {% from "elasticsearch/settings.sls" import elasticsearch with context %}
 
-{%- if elasticsearch.major_version == 5 %}
+{%- if elasticsearch.major_version == 5 or elasticsearch.major_version == 6 %}
 {%- set jvm_opts = salt['pillar.get']('elasticsearch:jvm_opts') %}
 {%- if jvm_opts %}
 /etc/elasticsearch/jvm.options:

--- a/elasticsearch/plugins.sls
+++ b/elasticsearch/plugins.sls
@@ -4,7 +4,7 @@ include:
 {% from "elasticsearch/settings.sls" import elasticsearch with context %}
 {%- set plugins_pillar = salt['pillar.get']('elasticsearch:plugins', {}) %}
 
-{% if elasticsearch.major_version == 5 %}
+{% if elasticsearch.major_version == 5 or elasticsearch.major_version == 6 %}
   {%- set plugin_bin = 'elasticsearch-plugin' %}
 {% else %}
   {%- set plugin_bin = 'plugin' %}

--- a/elasticsearch/repo.sls
+++ b/elasticsearch/repo.sls
@@ -1,6 +1,6 @@
 {% from "elasticsearch/settings.sls" import elasticsearch with context %}
 
-{%- if elasticsearch.major_version == 5 %}
+{%- if elasticsearch.major_version == 5 or elasticsearch.major_version == 6 %}
   {%- set repo_url = 'https://artifacts.elastic.co/packages/5.x' %}
 {%- else %}
   {%- set repo_url = 'http://packages.elastic.co/elasticsearch/2.x' %}

--- a/elasticsearch/repo.sls
+++ b/elasticsearch/repo.sls
@@ -1,6 +1,8 @@
 {% from "elasticsearch/settings.sls" import elasticsearch with context %}
 
-{%- if elasticsearch.major_version == 5 or elasticsearch.major_version == 6 %}
+{%- if elasticsearch.major_version == 6 %}
+  {%- set repo_url = 'https://artifacts.elastic.co/packages/6.x' %}
+{%- elif elasticsearch.major_version == 5 %}
   {%- set repo_url = 'https://artifacts.elastic.co/packages/5.x' %}
 {%- else %}
   {%- set repo_url = 'http://packages.elastic.co/elasticsearch/2.x' %}


### PR DESCRIPTION
With the latest version of Elasticsearch, can we update major_version comparisons to include version 6?