### PR TITLE
Fix for issue #54

### DIFF
--- a/elasticsearch/config.sls
+++ b/elasticsearch/config.sls
@@ -27,3 +27,8 @@ elasticsearch_cfg:
       - service: elasticsearch
 {% endif %}
 {% endfor %}
+
+elasticsearch_keystore_create:
+  cmd.run:
+    - name: cd /etc/elasticsearch && /usr/share/elasticsearch/bin/elasticsearch-keystore create
+    - unless: test -f /etc/elasticsearch/elasticsearch.keystore


### PR DESCRIPTION
Adds basic functionality to create a keystore at /etc/elasticsearch/elasticsearch.keystore if one does not already exist.