### PR TITLE
Python 3 compatibility

### DIFF
--- a/elasticsearch/files/sysconfig
+++ b/elasticsearch/files/sysconfig
@@ -1,6 +1,6 @@
 {%- if 'JAVA_HOME' not in sysconfig.keys() %}
 JAVA_HOME=/usr/lib/java
 {% endif %}
-{%- for key, value in sysconfig.iteritems() -%}
+{%- for key, value in sysconfig.items() -%}
 {{ key }}="{{ value }}"
 {% endfor %}


### PR DESCRIPTION
The fact that `items()` returns a list in Python should have no effect, as the list is not going to be massive.

Fixes #57 
I haven't found any other incompatibilities.