### PR TITLE
fix writing sysconfig file for python3

### DIFF
--- a/elasticsearch/files/sysconfig
+++ b/elasticsearch/files/sysconfig
@@ -1,6 +1,6 @@
 {%- if 'JAVA_HOME' not in sysconfig.keys() %}
 JAVA_HOME=/usr/lib/java
 {% endif %}
-{%- for key, value in sysconfig.iteritems() -%}
+{%- for key, value in sysconfig.items() -%}
 {{ key }}="{{ value }}"
 {% endfor %}


### PR DESCRIPTION
iteritems() no longer exists, use items() instead