### PR TITLE
Fix dependency to refer to the state name

### DIFF
--- a/elasticsearch/service.sls
+++ b/elasticsearch/service.sls
@@ -11,4 +11,4 @@ elasticsearch_service:
       - file: elasticsearch_cfg
 {%- endif %}
     - require:
-      - pkg: elasticsearch
+      - pkg: elasticsearch_pkg


### PR DESCRIPTION
Refering to the package name breaks when using a non-default packagename
via elasticsearch.pkg.