### PR TITLE
Added pipe to YAML for JVM Options Contents

### DIFF
--- a/elasticsearch/jvmopts.sls
+++ b/elasticsearch/jvmopts.sls
@@ -11,7 +11,7 @@ include:
     - mode: 0770
     - user: elasticsearch
     - group: elasticsearch
-    - contents: {{ jvm_opts }}
+    - contents: {{ jvm_opts | json }}
     - watch_in:
       - service: elasticsearch
 {% endif -%}

--- a/elasticsearch/jvmopts.sls
+++ b/elasticsearch/jvmopts.sls
@@ -11,7 +11,7 @@ include:
     - mode: 0770
     - user: elasticsearch
     - group: elasticsearch
-    - contents: {{ jvm_opts | json }}
+    - contents: {{ jvm_opts | yaml }}
     - watch_in:
       - service: elasticsearch
 {% endif -%}


### PR DESCRIPTION
**Issue:** When Salt renders the pillar file, an error is thrown for `unexpected ':'` or `unexpected end of stream`.

**Cause:** This is likely from the output not being rendered as JSON/YAML and taking `:` and `}` as literal characters.

**Fix:** Added a pipe to `yaml` to the `contents` field. (Line 14)

**Update**: This was intitially JSON but has since been changed to `yaml`