### PR TITLE
Add jvm_opts to example pillar

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -23,3 +23,17 @@ elasticsearch:
   plugins:
     lang-python: lang-python
     kopf: lmenezes/elasticsearch-kopf
+  jvm_opts:
+    - -XX:+HeapDumpOnOutOfMemoryError
+    - -XX:HeapDumpPath=/var/lib/elasticsearch
+    - -XX:ErrorFile=/var/log/elasticsearch/hs_err_pid%p.log
+    - 8:-XX:+PrintGCDetails
+    - 8:-XX:+PrintGCDateStamps
+    - 8:-XX:+PrintTenuringDistribution
+    - 8:-XX:+PrintGCApplicationStoppedTime
+    - 8:-Xloggc:/var/log/elasticsearch/gc.log
+    - 8:-XX:+UseGCLogFileRotation
+    - 8:-XX:NumberOfGCLogFiles=32
+    - 8:-XX:GCLogFileSize=64m
+    - 9-:-Xlog:gc*,gc+age=trace,safepoint:file=/var/log/elasticsearch/gc.log:utctime,pid,tags:filecount=32,filesize=64m
+    - 9-:-Djava.locale.providers=COMPAT


### PR DESCRIPTION
The feature isn't otherwise documented.

These are the Debain defaults. The state just replaces the whole file.